### PR TITLE
Bump ubuntu, node, GH action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,17 +4,17 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [22]
 
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: "Install dependencies"
@@ -30,4 +30,3 @@ jobs:
         run: npm run deploy
         env:
           AIRTABLE_PERSONAL_ACCESS_TOKEN: ${{ secrets.AIRTABLE_PERSONAL_ACCESS_TOKEN }}
-


### PR DESCRIPTION
See https://github.com/bluedotimpact/ai-evaluator-extension/pull/11#issue-3642934419